### PR TITLE
Memory fixes (FERTIOS-550)

### DIFF
--- a/src/KalViewController.h
+++ b/src/KalViewController.h
@@ -24,14 +24,12 @@
 {
   KalLogic *logic;
   UITableView *tableView;
-  id /*<UITableViewDelegate>*/ __unsafe_unretained delegate;
-  id <KalDataSource> __unsafe_unretained dataSource;
   NSDate *initialDate;                    // The date that the calendar was initialized with *or* the currently selected date when the view hierarchy was torn down in order to satisfy a low memory warning.
   NSDate *selectedDate;                   // I cache the selected date because when we respond to a memory warning, we cannot rely on the view hierarchy still being alive, and thus we cannot always derive the selected date from KalView's selectedDate property.
 }
 
-@property (nonatomic, unsafe_unretained) id<UITableViewDelegate> delegate;
-@property (nonatomic, unsafe_unretained) id<KalDataSource> dataSource;
+@property (nonatomic, weak) id<UITableViewDelegate> delegate;
+@property (nonatomic, weak) id<KalDataSource> dataSource;
 @property (nonatomic, strong, readonly) NSDate *selectedDate;
 
 - (id)initWithSelectedDate:(NSDate *)selectedDate;  // designated initializer. When the calendar is first displayed to the user, the month that contains 'selectedDate' will be shown and the corresponding tile for 'selectedDate' will be automatically selected.

--- a/src/KalViewController.m
+++ b/src/KalViewController.m
@@ -38,7 +38,7 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
 
 @implementation KalViewController
 
-@synthesize dataSource, delegate, initialDate, selectedDate;
+@synthesize initialDate, selectedDate;
 
 - (id)initWithSelectedDate:(NSDate *)date
 {
@@ -61,29 +61,29 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
 
 - (void)setDataSource:(id<KalDataSource>)aDataSource
 {
-  if (dataSource != aDataSource) {
-    dataSource = aDataSource;
-    tableView.dataSource = dataSource;
+  if (self.dataSource != aDataSource) {
+    _dataSource = aDataSource;
+    tableView.dataSource = self.dataSource;
   }
 }
 
 - (void)setDelegate:(id<UITableViewDelegate>)aDelegate
 {
-  if (delegate != aDelegate) {
-    delegate = aDelegate;
-    tableView.delegate = delegate;
+  if (self.delegate != aDelegate) {
+    _delegate = aDelegate;
+    tableView.delegate = self.delegate;
   }
 }
 
 - (void)clearTable
 {
-  [dataSource removeAllItems];
+  [self.dataSource removeAllItems];
   [tableView reloadData];
 }
 
 - (void)reloadData
 {
-  [dataSource presentingDatesFrom:logic.fromDate to:logic.toDate delegate:self];
+  [self.dataSource presentingDatesFrom:logic.fromDate to:logic.toDate delegate:self];
 }
 
 - (void)significantTimeChangeOccurred
@@ -111,7 +111,7 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
   NSDate *from = [[date NSDate] cc_dateByMovingToBeginningOfDay];
   NSDate *to = [[date NSDate] cc_dateByMovingToEndOfDay];
   [self clearTable];
-  [dataSource loadItemsFromDate:from toDate:to];
+  [self.dataSource loadItemsFromDate:from toDate:to];
   [tableView reloadData];
   [tableView flashScrollIndicators];
 
@@ -206,8 +206,8 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
   KalView *kalView = [[KalView alloc] initWithFrame:frame delegate:self logic:logic];
   self.view = kalView;
   tableView = kalView.tableView;
-  tableView.dataSource = dataSource;
-  tableView.delegate = delegate;
+  tableView.dataSource = self.dataSource;
+  tableView.delegate = self.delegate;
   tableView.showsVerticalScrollIndicator = NO;
   [kalView selectDate:[KalDate dateFromNSDate:self.initialDate]];
   [self reloadData];


### PR DESCRIPTION
The `unsafe_unretained` memory management attribute causes objects to be deallocated just as they would be with `weak`, but the pointers are not nilled out.

I think Crashlytics crashes [#3](https://fabric.io/ovuline2/ios/apps/com.ovuline/issues/563b75a6f5d3a7f76b57f138) and [#6](https://fabric.io/ovuline2/ios/apps/com.ovuline/issues/563b8a30f5d3a7f76b586f57) are attributable to `delegate` and `dataSource` being left as dangling pointers.

Of course, this changeset doesn't fully address the problem that `KalViewController` instances created by  `OVGetStartedVC` are left in memory indefinitely and continue receiving  `UIApplicationSignificantTimeChangeNotification` messages long after the UI is gone from screen (see JIRA ticket).
