### PR TITLE
Resolve root cause of FERTIOS-550 crashes

### DIFF
--- a/src/KalGridView.h
+++ b/src/KalGridView.h
@@ -20,7 +20,6 @@
  */
 @interface KalGridView : UIView
 {
-  id<KalViewDelegate> delegate;  // Assigned.
   KalLogic *logic;
   KalMonthView *frontMonthView;
   KalMonthView *backMonthView;
@@ -31,6 +30,8 @@
 
 @property (nonatomic, readonly) BOOL transitioning;
 @property (unsafe_unretained, nonatomic, readonly) KalDate *selectedDate;
+
+@property (weak, nonatomic) id<KalViewDelegate> delegate;
 
 - (id)initWithFrame:(CGRect)frame logic:(KalLogic *)logic delegate:(id<KalViewDelegate>)delegate;
 - (void)selectDate:(KalDate *)date;

--- a/src/KalGridView.m
+++ b/src/KalGridView.m
@@ -47,7 +47,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
     self.clipsToBounds = YES;
 	
     logic = theLogic;
-    delegate = theDelegate;
+    _delegate = theDelegate;
     
     CGRect monthRect = CGRectMake(1.f, 0.f, frame.size.width-2, frame.size.height);
     frontMonthView = [[KalMonthView alloc] initWithFrame:monthRect];
@@ -106,10 +106,10 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
     selectedTile.selected = NO;
     selectedTile = tile;
     tile.selected = YES;
-    [delegate didSelectDate:tile.date];
+    [self.delegate didSelectDate:tile.date];
   }
   else {
-      [delegate didSelectDate:tile.date];
+      [self.delegate didSelectDate:tile.date];
   }
 }
 
@@ -119,7 +119,7 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
         selectedTile.selected = NO;
         selectedTile = tile;
 //        tile.selected = YES;
-        [delegate didSelectDate:nil];
+        [self.delegate didSelectDate:nil];
 //    }
 }
 
@@ -163,9 +163,9 @@ static NSString *kSlideAnimationId = @"KalSwitchMonths";
     KalTileView *tile = (KalTileView*)hitView;
     if (tile.belongsToAdjacentMonth) {
       if ([tile.date compare:[KalDate dateFromNSDate:logic.baseDate]] == NSOrderedDescending) {
-        [delegate showFollowingMonth];
+        [self.delegate showFollowingMonth];
       } else {
-        [delegate showPreviousMonth];
+        [self.delegate showPreviousMonth];
       }
       self.selectedTile = [frontMonthView tileForDate:tile.date];
     } else {

--- a/src/KalViewController.m
+++ b/src/KalViewController.m
@@ -213,12 +213,6 @@ NSString *const KalDataSourceChangedNotification = @"KalDataSourceChangedNotific
   [self reloadData];
 }
 
-- (void)viewDidUnload
-{
-  [super viewDidUnload];
-  tableView = nil;
-}
-
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];


### PR DESCRIPTION
`KalViewController` was being incorrectly retained due to a `strong` delegate property. This was why the controller never unregistered from `UIApplicationSignificantTimeChangeNotification` messages.
